### PR TITLE
Bug in ResidualVectorQuantizer

### DIFF
--- a/soundstream.py
+++ b/soundstream.py
@@ -238,7 +238,7 @@ class ResidualVectorQuantizer(nn.Module):
         # input: [..., chennel]
         if self.training:
             # Enabling bitrate scalability with quantizer dropout
-            n = random.randrange(1, self.num_quantizers)
+            n = random.randint(1, self.num_quantizers)
         else:
             n = self.num_quantizers
         codes = []


### PR DESCRIPTION
Fix #7 

https://github.com/kaiidams/soundstream-pytorch/blob/9c6086e4fccaf75adb3f62014f750843fc68d84e/soundstream.py#L241

`n` here is `[1, self.num_quantizers)` but should be `[1, self.num_quantizers]`.
